### PR TITLE
Ensure that N2J_NetworkInfo uses Make function with Channel and PAN ID

### DIFF
--- a/src/device-manager/java/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/java/WeaveDeviceManager-JNI.cpp
@@ -3113,7 +3113,7 @@ WEAVE_ERROR N2J_NetworkInfo(JNIEnv *env, const NetworkInfo& inNetworkInfo, jobje
         SuccessOrExit(err);
     }
 
-    makeMethod = env->GetStaticMethodID(sNetworkInfoCls, "Make", "(IJLjava/lang/String;III[BLjava/lang/String;[B[BS)Lnl/Weave/DeviceManager/NetworkInfo;");
+    makeMethod = env->GetStaticMethodID(sNetworkInfoCls, "Make", "(IJLjava/lang/String;III[BLjava/lang/String;[B[BSIB)Lnl/Weave/DeviceManager/NetworkInfo;");
     VerifyOrExit(makeMethod != NULL, err = WDM_JNI_ERROR_METHOD_NOT_FOUND);
 
     env->ExceptionClear();


### PR DESCRIPTION
Currently this JNI conversion is using the NetworkInfo.Make() overload which does not take in a channel and PAN ID. Unfortunately, JNI doesn't complain if you pass too many arguments with the invocation, so the channel and PAN ID were being ignored.